### PR TITLE
Improve windows documentation and fixes for use in powershell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.agda~
 *.agdai
-_build
-build
+dist-newstyle

--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ build:
 	@echo == Compiling Agda code ==
 	agda2hs -olib -i. Everything.agda
 	@echo == Compiling Haskell code ==
-	cabal build all --allow-newer=base
+	cabal build all

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@
 default: build
 
 build:
-	mkdir -p build
 	@echo == Compiling Agda code ==
 	agda2hs -olib -i. Everything.agda
 	@echo == Compiling Haskell code ==
-	cabal build all
+	cabal build all --allow-newer=base

--- a/README.md
+++ b/README.md
@@ -2,20 +2,25 @@
 
 ## Prerequisites:
 
-To use this template it is necessary to have cabal, ghc and make installed. If you don't have these installed you can follow the instructions below, else you can continue on to [here.](#dependencies)
+To use this template it is necessary to have cabal, ghc and make installed. If
+you don't have these installed you can follow the instructions below, else you
+can continue on to [here.](#dependencies)
 
 ### For Windows (Using Chocolately):
 
-It is recommended that you install chocolately as a package manager that allows for installing software by using the built-in terminal in Windows.
-For the latest instruction on installing chocolately [click here](https://chocolatey.org/install#individual) and use the individual installation method.
+It is recommended that you install chocolately as a package manager that allows
+for installing software by using the built-in terminal in Windows. For the
+latest instruction on installing chocolately [click
+here](https://chocolatey.org/install#individual) and use the individual
+installation method.
 
-To install all prerequisites execute the following codes in your terminal:
+To install all prerequisites execute the following commands in your terminal:
 ```
 choco install ghc cabal make
 refreshenv
 ```
 
-Now you're good to go to for installing the dependencies.
+Now you can go ahead and install the dependencies.
 
 ## Dependencies
 
@@ -25,7 +30,7 @@ To build them from source, do the following:
 ```
 git clone https://github.com/flupe/verification-template
 cd verification-template
-cabal install Agda # If there are conflicting dependencies for base use the following flag: --allow-newer=base
+cabal install Agda    # If there are conflicting dependencies for base use the following flag: --allow-newer=base
 cabal install agda2hs # If there are conflicting dependencies for base use the following flag: --allow-newer=base
 ```
 
@@ -40,6 +45,7 @@ Clone Jesper's fork of agda2hs:
 git clone -b erasure-annotations https://github.com/jespercockx/agda2hs
 ```
 ### For Unix:
+
 Inside the file `~/.agda/libraries`, add the following line:
 
 ```
@@ -66,9 +72,7 @@ Or run the following command in powershell:
 add-content $home\AppData\Roaming\agda\libraries "`n</your/path/to/agda2hs/agda2hs.agda-lib>"
 ```
 
-<br>
-
-You're all set!
+*You will have to create this file if it does not exist.*
 
 ## Development
 
@@ -85,3 +89,6 @@ Running `make` at the root of the project will:
 [Agda]:    https://github.com/agda/Agda
 [agda2hs]: https://github.com/agda/agda2hs
 
+To run the demo executable, just launch `cabal run demo`.
+
+To test out your library in a REPL, use `cabal repl project`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 # Template for Practical Verification of Functional Libraries
 
+## Prerequisites:
+
+To use this template it is necessary to have cabal, ghc and make installed. If you don't have these installed you can follow the instructions below, else you can continue on to [here.](#dependencies)
+
+### For Windows (Using Chocolately):
+
+It is recommended that you install chocolately as a package manager that allows for installing software by using the built-in terminal in Windows.
+For the latest instruction on installing chocolately [click here](https://chocolatey.org/install#individual) and use the individual installation method.
+
+To install all prerequisites execute the following codes in your terminal:
+```
+choco install ghc cabal make
+refreshenv
+```
+
+Now you're good to go to for installing the dependencies.
+
 ## Dependencies
 
 This template relies on a custom fork of both [agda2hs] and [Agda].
@@ -8,8 +25,8 @@ To build them from source, do the following:
 ```
 git clone https://github.com/flupe/verification-template
 cd verification-template
-cabal install Agda
-cabal install agda2hs
+cabal install Agda # If there are conflicting dependencies for base use the following flag: --allow-newer=base
+cabal install agda2hs # If there are conflicting dependencies for base use the following flag: --allow-newer=base
 ```
 
 Building Agda may take a while.
@@ -22,18 +39,28 @@ Clone Jesper's fork of agda2hs:
 ```
 git clone -b erasure-annotations https://github.com/jespercockx/agda2hs
 ```
-
+### For Unix:
 Inside the file `~/.agda/libraries`, add the following line:
 
 ```
 /your/path/to/agda2hs/agda2hs.agda-lib
 ```
 
+### For Windows:
+Inside the file `C:\Users\<USER>\AppData\Roaming\agda\libraries`, add the following line:
+
+
+```
+/your/path/to/agda2hs/agda2hs.agda-lib
+```
+
+<br>
+
 You're all set!
 
 ## Development
 
-You should be good to go. Open any file in the `src/` directory inside emacs and
+You should be good to go. Open any file in the `src/` directory inside your IDE of choice and
 you should be able to use the Haskell prelude in your code without any issue.
 
 Running `make` at the root of the project will:

--- a/README.md
+++ b/README.md
@@ -47,11 +47,23 @@ Inside the file `~/.agda/libraries`, add the following line:
 ```
 
 ### For Windows:
-Inside the file `C:\Users\<USER>\AppData\Roaming\agda\libraries`, add the following line:
 
+First off execute the following command:
 
 ```
-/your/path/to/agda2hs/agda2hs.agda-lib
+(test-path -path $home\AppData\Roaming\agda\libraries -pathtype Leaf) ? (echo "File not created, it already exists") : (new-item -path $home\AppData\Roaming\agda\libraries)
+```
+
+Either add the following line to `C:\Users\<USER>\AppData\Roaming\agda\libraries` or alternatively when using powershell `$home\AppData\Roaming\agda\libraries`, 
+
+```
+</your/path/to/agda2hs/agda2hs.agda-lib>
+```
+
+Or run the following command in powershell:
+
+```
+add-content $home\AppData\Roaming\agda\libraries "`n</your/path/to/agda2hs/agda2hs.agda-lib>"
 ```
 
 <br>

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,5 @@
 packages: .
+allow-newer: base
 
 source-repository-package
         type: git
@@ -9,3 +10,4 @@ source-repository-package
         type: git
         location: https://github.com/jespercockx/agda2hs
         tag: a1af67414851a6e9d714c5e7e71e69bf5d60a41f
+

--- a/lib/Data/Tree.hs
+++ b/lib/Data/Tree.hs
@@ -1,0 +1,38 @@
+module Data.Tree where
+
+data Tree a = Leaf
+            | Node a (Tree a) (Tree a)
+                deriving Show
+
+instance Foldable Tree where
+    foldMap f Leaf = mempty
+    foldMap f (Node x l r) = foldMap f l <> f x <> foldMap f r
+
+instance Functor Tree where
+    fmap f Leaf = Leaf
+    fmap f (Node x l r) = Node (f x) (fmap f l) (fmap f r)
+
+instance Traversable Tree where
+    traverse f Leaf = pure Leaf
+    traverse f (Node x l r)
+      = pure Node <*> f x <*> traverse f l <*> traverse f r
+
+size :: Tree a -> Integer
+size Leaf = 0
+size (Node x l r) = 1 + size l + size r
+
+depth :: Tree a -> Integer
+depth Leaf = 0
+depth (Node x l r) = 1 + max (depth l) (depth r)
+
+insert :: Ord a => a -> Tree a -> Tree a
+insert v Leaf = Node v Leaf Leaf
+insert v (Node x l r)
+  = case compare v x of
+        LT -> Node x (insert v l) r
+        EQ -> Node x l r
+        GT -> Node x l (insert v r)
+
+fromList :: Ord a => [a] -> Tree a
+fromList = foldr insert Leaf
+

--- a/project.cabal
+++ b/project.cabal
@@ -7,8 +7,7 @@ library
   default-language: Haskell2010
   hs-source-dirs:   lib
   build-depends:    base >= 4.11 && < 5
-  exposed-modules: Data.Tree
-  autogen-modules:  Data.Tree
+  exposed-modules:  Data.Tree
 
 executable demo
   hs-source-dirs:   demo

--- a/project.cabal
+++ b/project.cabal
@@ -1,12 +1,13 @@
 name:          project
 version:       0.0.0
-cabal-version: >= 1.10
+cabal-version: >= 2.0
 build-type:    Simple
 
 library
   default-language: Haskell2010
   hs-source-dirs:   lib
   build-depends:    base >= 4.11 && < 5
+  exposed-modules: Data.Tree
   autogen-modules:  Data.Tree
 
 executable demo

--- a/project.cabal
+++ b/project.cabal
@@ -1,16 +1,17 @@
 name:          project
 version:       0.0.0
-cabal-version: >= 2.0
+cabal-version: >= 1.10
 build-type:    Simple
 
 library
   default-language: Haskell2010
   hs-source-dirs:   lib
-  build-depends:    base >= 4.11 && < 5
+  build-depends:    base
   exposed-modules:  Data.Tree
 
 executable demo
+  default-language: Haskell2010
   hs-source-dirs:   demo
   main-is:          Main.hs
-  build-depends:    base >= 4.11 && < 5
+  build-depends:    base
                   , project

--- a/project.cabal
+++ b/project.cabal
@@ -7,7 +7,7 @@ library
   default-language: Haskell2010
   hs-source-dirs:   lib
   build-depends:    base >= 4.11 && < 5
-  exposed-modules:  Data.Tree
+  autogen-modules:  Data.Tree
 
 executable demo
   hs-source-dirs:   demo


### PR DESCRIPTION
Did the following:
- Added documentation to install cabal/ghc/make via chocolately for windows.
- Added windows specific paths that do not work with the provided unix ones.
- Added dirty fix for base dependencies colliding by using --allow-newer in documentation as well as make file.
- Fixed .cabal for windows
- Removed mkdir -p build (windows doesn't allow flags) and just removed the line, make seemed to just create a _build directory by itself. Would like to know if the makefile still works on unix? 