### PR TITLE
Added clean with platform agnostic workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.agda~
 *.agdai
 dist-newstyle
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
-.PHONY: default build
+.PHONY: default
 
-default: build
+default: full_build
+
+clean:
+	@echo == Cleaning Haskell code directory ==
+	@rmdir /s /q lib ||:
+	@rm -r lib/ ||:
+	@echo == Cleaning Success ==
 
 build:
 	@echo == Compiling Agda code ==
 	agda2hs -olib -i. Everything.agda
 	@echo == Compiling Haskell code ==
 	cabal build all
+
+full_build: clean build 


### PR DESCRIPTION
Yeah this isn't a pretty script. I first wanted to use ifeq like a in a proper Makefile but then windows started acting up with not being able to find that specific command. Read on stack overflow that it could be several issues with the path so I decided I wouldn't bother  and work around it for now. (Because fixing path issues would make running this template a lot worse)

So right now I just added an or true to the back of the clean operations for both unix and windows and the only ugly thing remaining is that your terminal complains that it it doesn't recognize the command. No clue how to suppress that so if you know if that's possible that would be great.

This does fix the issue of lingering code in your build output and should also prevent people from writing huge swats of haskell code in the lib build folder.

Also added .vscode to gitignore. (I was also thinking of adding the lib file to gitignore because it's build output but that might cause some confusion?)
